### PR TITLE
Fix disk import path, bootindex and scsi bus issues

### DIFF
--- a/pkg/api/network.go
+++ b/pkg/api/network.go
@@ -41,6 +41,13 @@ type NicDef struct {
 	BootIndex *int       `yaml:"bootindex,omitempty`
 }
 
+func (n *NicDef) BootIndexValue() int {
+	if n.BootIndex != nil {
+		return *n.BootIndex
+	}
+	return -1
+}
+
 type VMNic struct {
 	BusAddr    string
 	DeviceType string

--- a/pkg/api/vm.go
+++ b/pkg/api/vm.go
@@ -83,8 +83,8 @@ func (v *VMDef) adjustDiskBootIdx(qti *qcli.QemuTypeIndex) ([]int, error) {
 			*idx = qti.NextBootIndex()
 			disk.BootIndex = idx
 		} else {
-			if err := qti.SetBootIndex(*disk.BootIndex); err != nil {
-				return []int{}, fmt.Errorf("Failed to set Disk %s BootIndex %d: %s", disk.File, *disk.BootIndex, err)
+			if err := qti.SetBootIndex(disk.BootIndexValue()); err != nil {
+				return []int{}, fmt.Errorf("Failed to set BootIndex %d on disk %s: %s", disk.BootIndexValue(), disk.File, err)
 			}
 		}
 		allocated = append(allocated, *disk.BootIndex)
@@ -102,7 +102,7 @@ func (v *VMDef) adjustNetBootIdx(qti *qcli.QemuTypeIndex) ([]int, error) {
 			nic.BootIndex = idx
 		} else {
 			if err := qti.SetBootIndex(*nic.BootIndex); err != nil {
-				return []int{}, fmt.Errorf("Failed to set Nic %s BootIndex %d: %s", nic.Device, *nic.BootIndex, err)
+				return []int{}, fmt.Errorf("Failed to set BootIndex %d on nic %s: %s", *nic.BootIndex, nic.Device, err)
 			}
 		}
 		allocated = append(allocated, *nic.BootIndex)


### PR DESCRIPTION
In the process of attempting to boot a cloud image to fix the import of a local disk image a few more things were fixed:

- For scsi-hd disks (the default if untyped) the bus= parameter refers to the single virtio-scsi-pci device, mapped to the name 'scsi0.0'
- Add BootIndexValue() function to get the value of the *int in the structure.
- Check the return value from AdjustBootIndicices, was ignoring the duplicate bootindex value and only noticed when qemu didn't lauch
- Check for Boot=cdrom and ensure we set that bootindex first.
- Removed dead code from disk.go

Fixes: #4 