### PR TITLE
Use IDE for cdroms to be more friendly to legacy ISO images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,11 @@ require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/lxc/lxd v0.0.0-20221130220346-2c77027b7a5e
 	github.com/msoap/byline v1.1.1
-	github.com/raharper/qcli v0.0.2
+	github.com/raharper/qcli v0.0.6
 	github.com/rodaine/table v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
-	github.com/yourbasic/bit v0.0.0-20180313074424-45a4409f4082
 	golang.org/x/sys v0.2.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -52,6 +51,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
+	github.com/yourbasic/bit v0.0.0-20180313074424-45a4409f4082 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/term v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6kt
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/raharper/qcli v0.0.2 h1:2AsNQms/1zm0RuvT2hzl7fhGbHN0Sx9Hn2msvRQ27TY=
-github.com/raharper/qcli v0.0.2/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
+github.com/raharper/qcli v0.0.6 h1:O542wUJ4Bn4BVxx4Gnj1psiy5KEksaNCmFcbJR21rSo=
+github.com/raharper/qcli v0.0.6/go.mod h1:2V3cMEpdXCSWz5cqXnbBFsnLM8j81PfklKKVF1aE0RE=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=


### PR DESCRIPTION
Generally we'd prefer to use virtio-blk for better performance with ISOs but some code may expect isos to be in the /dev/cdrom path which isn't the case with virtio-blk as cdrom devices.  Go ahead and use a legacy AHCI controller and ide-cd device.

- Updated to qcli v0.0.6 release to pickup IDEControllerDevices in the Config object, and BootIndex as strings
- Remove some cdrom debug messages
- Fix up the BlockDevice and Bus attach code for IDE CDROMs