### PR TITLE
bootindex: once more into the breach dear friends

### DIFF
--- a/pkg/api/disk.go
+++ b/pkg/api/disk.go
@@ -49,15 +49,8 @@ type QemuDisk struct {
 	Type      string   `yaml:"type"`
 	BlockSize int      `yaml:"blocksize,omitempty"`
 	BusAddr   string   `yaml:"addr,omitempty"`
-	BootIndex *int     `yaml:"bootindex,omitempty"`
+	BootIndex string   `yaml:"bootindex,omitempty"`
 	ReadOnly  bool     `yaml:"read-only,omitempty"`
-}
-
-func (q *QemuDisk) BootIndexValue() int {
-	if q.BootIndex != nil {
-		return *q.BootIndex
-	}
-	return -1
 }
 
 func (q *QemuDisk) Sanitize(basedir string) error {

--- a/pkg/api/network.go
+++ b/pkg/api/network.go
@@ -38,14 +38,7 @@ type NicDef struct {
 	ifname    string     `yaml:"ifname",omitempty`
 	Network   string     `yaml:"network",omitempty`
 	Ports     []PortRule `yaml:"ports",omitempty`
-	BootIndex *int       `yaml:"bootindex,omitempty`
-}
-
-func (n *NicDef) BootIndexValue() int {
-	if n.BootIndex != nil {
-		return *n.BootIndex
-	}
-	return -1
+	BootIndex string     `yaml:"bootindex,omitempty`
 }
 
 type VMNic struct {
@@ -57,7 +50,7 @@ type VMNic struct {
 	NetIFName  string
 	NetType    string
 	NetAddr    string
-	BootIndex  int
+	BootIndex  string
 	Ports      []PortRule
 }
 


### PR DESCRIPTION
OK.  QEMU uses zero-based bootindex values, and using an int for the type of the BootIndex field made it difficult to distinguished between unset and the value of zero.... yeah.

Let's go back to strings for BootIndex as a string type which is easy to see if it's unset (empty) and then use strconv/sprintf to switch between string and int as needed.